### PR TITLE
fix: resolve dashboard test crash (Jest 30 compat) and page.html unicode (#4)

### DIFF
--- a/__tests__/sample-problem.test.js
+++ b/__tests__/sample-problem.test.js
@@ -63,4 +63,44 @@ describe('Bundled Sample Problem', () => {
       expect(content).toContain('// @version');
     }
   });
+
+  test('no unicode escape sequences in template files', () => {
+    const textExtensions = ['.ts', '.html', '.json', '.css', '.js', '.md'];
+
+    function walkDir(dir) {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      const files = [];
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+        if (entry.isDirectory()) {
+          files.push(...walkDir(fullPath));
+        } else if (textExtensions.some(ext => entry.name.endsWith(ext))) {
+          files.push(fullPath);
+        }
+      }
+      return files;
+    }
+
+    const files = walkDir(TEMPLATE_DIR);
+    const unicodeEscapePattern = /\\u[0-9a-fA-F]{4}/;
+
+    for (const filePath of files) {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const relativePath = path.relative(TEMPLATE_DIR, filePath);
+      expect(unicodeEscapePattern.test(content)).toBe(false);
+    }
+  });
+
+  test('dashboard jest command uses --experimental-vm-modules and --testPathPatterns', () => {
+    const dashboardPath = path.join(TEMPLATE_DIR, 'scripts', 'dashboard.ts');
+    const content = fs.readFileSync(dashboardPath, 'utf-8');
+
+    // Must use --experimental-vm-modules for ESM support
+    expect(content).toContain('--experimental-vm-modules');
+
+    // Must use --testPathPatterns (plural) — Jest 30 removed the singular form
+    expect(content).toContain('--testPathPatterns');
+    expect(content).not.toMatch(/--testPathPattern[^s]/);
+  });
 });

--- a/_template/scripts/dashboard.ts
+++ b/_template/scripts/dashboard.ts
@@ -1,4 +1,4 @@
-// @version 1.2.0
+// @version 1.2.1
 /**
  * ─── DSA Lab — Unified Dashboard ──────────────────────────────
  *
@@ -248,7 +248,7 @@ function testProblem(problem: ProblemFile): void {
   console.log(chalk.dim(`\n  ─── Testing ${problem.name} ────────────────────────\n`));
   try {
     execSync(
-      `npx jest --testPathPattern="${problem.name}" --verbose --no-coverage`,
+      `node --experimental-vm-modules node_modules/.bin/jest --testPathPatterns="${problem.name}" --verbose --no-coverage`,
       { stdio: 'inherit', cwd: process.cwd() }
     );
   } catch {

--- a/_template/scripts/templates/page.html
+++ b/_template/scripts/templates/page.html
@@ -14,14 +14,14 @@
 <body>
   <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
-      <a href='/'>\ud83d\udcda DSA Notes</a>
-      <input type="text" class="search-box" id="search" placeholder="Search notes\u2026" autocomplete="off" />
+      <a href='/'>📚 DSA Notes</a>
+      <input type="text" class="search-box" id="search" placeholder="Search notes…" autocomplete="off" />
     </div>
     <nav class="sidebar-nav" id="nav">
       {{SIDEBAR}}
     </nav>
     <div class="sidebar-footer">
-      Dynamic \u2022 Auto-scans src folder
+      Dynamic • Auto-scans src folder
     </div>
   </aside>
 
@@ -31,7 +31,7 @@
     </div>
   </main>
 
-  <button class="menu-toggle" id="menuToggle">\u2630</button>
+  <button class="menu-toggle" id="menuToggle">☰</button>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>

--- a/changelogs/unreleased.md
+++ b/changelogs/unreleased.md
@@ -2,4 +2,7 @@
 - 
 
 ### 🐞 Bug Fixes
-- 
+- Fixed dashboard test action crash — added `--experimental-vm-modules` flag for ESM compatibility and updated `--testPathPattern` → `--testPathPatterns` for Jest 30 (#4)
+- Fixed remaining unicode escape sequences (`\ud83d\udcda`, `\u2026`, `\u2022`, `\u2630`) in `page.html` — now renders real emoji characters (#4)
+- Updated docs (`FILE_REFERENCE.md`, `HOW_IT_WORKS.md`) to reflect corrected Jest command
+- Added regression tests to prevent future unicode escape and Jest API regressions

--- a/docs/FILE_REFERENCE.md
+++ b/docs/FILE_REFERENCE.md
@@ -69,7 +69,7 @@ Everything in this directory becomes the user's project. Edit these files to cha
 | `pickProblem()` | Autocomplete file picker with fuzzy search |
 | `pickAction()` | Select menu: Run, Test, Benchmark, Notes, Back, Exit |
 | `runProblem()` | Dynamic import → execute with `sampleInput` → show result |
-| `testProblem()` | Shells out to `npx jest --testPathPattern=<name>` |
+| `testProblem()` | Shells out to `node --experimental-vm-modules ... jest --testPathPatterns=<name>` |
 | `benchProblem()` | Warm-up (5 runs) + N measured iterations → stats table |
 | `openNotes()` | Opens browser to notes server URL |
 | `watchAndRerun()` | Uses chokidar to watch `.ts` file, re-runs action on change |
@@ -201,7 +201,7 @@ Key scripts:
 |:--|:--|
 | `start` | `tsx scripts/dashboard.ts` |
 | `make` | `tsx scripts/generate.ts` |
-| `test` | `npx jest` |
+| `test` | `node --experimental-vm-modules node_modules/.bin/jest --watchAll` |
 | `notes` | `tsx scripts/serve-notes.ts` |
 
 ---

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -87,7 +87,7 @@ npm start
            ├──── Run ──────→ Dynamic import → execute fn(sampleInput)
            │                  → show output, time, pass/fail
            │
-           ├──── Test ─────→ execSync('npx jest --testPathPattern=...')
+           ├──── Test ─────→ execSync('node --experimental-vm-modules ... jest --testPathPatterns=...')
            │
            ├──── Bench ────→ Warm-up(5) → Measure(N iterations)
            │                  → avg/min/max time + memory delta


### PR DESCRIPTION
## Summary

Fixes #4 — resolves two bugs that PR #5 (v1.2.0) missed.

### Bug 1: Dashboard Test Execution Crashes ⚠️ Critical

The dashboard's `testProblem()` function had **two problems** in its Jest command:

| Problem | Before | After |
|:--|:--|:--|
| Missing ESM flag | `npx jest` | `node --experimental-vm-modules node_modules/.bin/jest` |
| Removed Jest 29 flag | `--testPathPattern` | `--testPathPatterns` (Jest 30 renamed it) |

**User flow that failed:** `npm start` → select problem → **Test** → crash

PR #5 fixed the `prompts` autocomplete typing, but never touched the actual Jest execution command.

### Bug 2: Unicode Escapes in `page.html`

PR #5 fixed unicode escapes in `config.ts`, `errors.ts`, `dsa-lab.config.json`, and `scanner.test.js` — but completely missed `page.html`. Four escape sequences (`\ud83d\udcda`, `\u2026`, `\u2022`, `\u2630`) remained as raw text instead of rendered characters (📚, …, •, ☰).

## Changes

| File | Change |
|:--|:--|
| `_template/scripts/dashboard.ts` | Fixed Jest command: added `--experimental-vm-modules`, changed `--testPathPattern` → `--testPathPatterns`. Bumped `@version` to 1.2.1 |
| `_template/scripts/templates/page.html` | Replaced 4 unicode escape sequences with actual characters |
| `docs/FILE_REFERENCE.md` | Updated `testProblem()` description and template test script reference |
| `docs/HOW_IT_WORKS.md` | Updated architecture diagram with correct Jest command |
| `__tests__/sample-problem.test.js` | Added 2 regression tests: unicode escape scanner + Jest command validation |
| `changelogs/unreleased.md` | Documented fixes for v1.2.1 |

## Testing

- ✅ New regression test scans entire `_template/` for unicode escapes
- ✅ New regression test verifies dashboard Jest command includes `--experimental-vm-modules` and `--testPathPatterns`
- All existing tests should continue to pass

## After Merge

Run `npm run release` → select **Patch** → publishes `v1.2.1` to npm